### PR TITLE
refactor: model 클래스 다중 책임 분리 및 단일 책임화

### DIFF
--- a/__tests__/RaceTest.js
+++ b/__tests__/RaceTest.js
@@ -1,5 +1,4 @@
 import Race from '../src/models/Race';
-import { Console } from '@woowacourse/mission-utils';
 
 describe('Race 실행 결과', () => {
   let race;
@@ -8,16 +7,21 @@ describe('Race 실행 결과', () => {
 
   beforeEach(() => {
     race = new Race();
-    scoreBoard = { tesla: 0, benz: 0 };
+    scoreBoard = [
+      ['tesla', 0],
+      ['benz', 0],
+    ];
     laps = 3;
   });
 
   test('`racing` 메소드 테스트', () => {
     const result = race.racing(scoreBoard, laps);
 
-    expect(result).toMatchObject([
-      ['tesla', expect.any(Number)],
-      ['benz', expect.any(Number)],
-    ]);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        ['tesla', expect.any(Number)],
+        ['benz', expect.any(Number)],
+      ]),
+    );
   });
 });

--- a/__tests__/RaceTest.js
+++ b/__tests__/RaceTest.js
@@ -12,23 +12,6 @@ describe('Race 실행 결과', () => {
     laps = 3;
   });
 
-  const getLogSpy = () => {
-    const logSpy = jest.spyOn(Console, 'print');
-    logSpy.mockClear();
-    return logSpy;
-  };
-
-  test('`showScoreBoard` 메소드 테스트', () => {
-    const ouputs = ['tesla : ', 'benz : '];
-    const logSpy = getLogSpy();
-
-    race.racing(scoreBoard, laps);
-
-    ouputs.forEach(output => {
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(output));
-    });
-  });
-
   test('`racing` 메소드 테스트', () => {
     const result = race.racing(scoreBoard, laps);
 

--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -2,8 +2,6 @@ const GUIDE_MESSAGES = Object.freeze({
   carNames: '경주할 자동차 이름을 입력하세요.(이름은 쉼표(,) 기준으로 구분)\n',
   laps: '시도할 횟수는 몇 회인가요?\n',
   output: '\n실행 결과',
-  whiteSpace: '',
-  dash: '-',
   lapScore: (carName, score) => `${carName} : ${score}`,
   finalWinner: winners => `최중 우승자 : ${winners}`,
 });

--- a/src/constants/options.js
+++ b/src/constants/options.js
@@ -1,6 +1,7 @@
 const OPTIONS = Object.freeze({
   maxNaming: 5,
   minLaps: 1,
+  defaultPoint: 0,
   point: 1,
   refuel: 4,
 });

--- a/src/constants/symbols.js
+++ b/src/constants/symbols.js
@@ -1,0 +1,8 @@
+const SYMBOLS = Object.freeze({
+  whiteSpace: '',
+  dash: '-',
+  comma: ',',
+  commaWithSpace: ', ',
+});
+
+export default SYMBOLS;

--- a/src/controller/GameController.js
+++ b/src/controller/GameController.js
@@ -6,9 +6,9 @@ import OutputView from '../views/OutputView.js';
 import Awards from '../models/Awards.js';
 
 class GameController {
-  #outputView;
+  #outputView = OutputView;
 
-  #inputView;
+  #inputView = InputView;
 
   #race;
 
@@ -18,14 +18,12 @@ class GameController {
 
   /**
    * GameController 인스턴스 생성
-   * @param {{[x: string]: number}} scoreBoard 스코어보드
+   * @param {[string, number][]} scoreBoard 스코어보드
    * @param {number} laps 시도할 횟수
    */
   constructor(scoreBoard, laps) {
     this.#race = new Race();
     this.#awards = new Awards();
-    this.#outputView = OutputView;
-    this.#inputView = InputView;
     this.scoreBoard = scoreBoard;
     this.laps = laps;
   }
@@ -34,33 +32,28 @@ class GameController {
    * 경주할 자동차 이름과 시도할 횟수를 입력받아 레이싱을 준비한다.
    */
   async ready() {
-    this.scoreBoard = Score.board(await this.#inputView.getCarNames());
+    this.scoreBoard = Score.getBoard(await this.#inputView.getCarNames());
     this.laps = await this.#inputView.getLaps();
-
-    await this.#start();
+    this.#startRace();
   }
 
   /**
    * 입력받은 자동차 이름과 횟수를 기반으로 레이스를 시작한다.
    * @private
    */
-  async #start() {
-    const { output } = GUIDE_MESSAGES;
-
-    this.#outputView.print(output);
-    this.result = this.#race.racing(this.scoreBoard, this.laps);
-    this.#end();
+  #startRace() {
+    this.#outputView.print(GUIDE_MESSAGES.output);
+    this.scoreBoard = this.#race.racing(this.scoreBoard, this.laps);
+    this.#endRace();
   }
 
   /**
    * 실행 결과 최종 우승자를 도출한다.
    * @private
    */
-  #end() {
-    const { finalWinner } = GUIDE_MESSAGES;
-
-    this.#winners = this.#awards.getWinners(this.result);
-    this.#outputView.print(finalWinner(this.#winners));
+  #endRace() {
+    this.#winners = this.#awards.getWinners(this.scoreBoard);
+    this.#outputView.print(GUIDE_MESSAGES.finalWinner(this.#winners));
   }
 }
 

--- a/src/models/Awards.js
+++ b/src/models/Awards.js
@@ -6,18 +6,35 @@ class Awards {
   }
 
   /**
-   *
-   * @param {[string, number][]} result
+   * 최대 점수와 도출해낸 점수 통해 우승자를 도출해낸다.
+   * @param {[string, number][]} scoreBoard
    * @returns {string}
    */
-  getWinners(result) {
-    this.#highestScore = result[0][1];
-    this.winners = result
-      .filter(score => this.#highestScore === score[1])
-      .map(score => score[0])
-      .join(', ');
+  getWinners(scoreBoard) {
+    this.#getHighestScore(scoreBoard);
+    this.#setWinners(scoreBoard);
 
     return this.winners;
+  }
+
+  /**
+   * 스코어보드의 가장 높은 점수를 도출해낸다.
+   * @param {[string, number][]} scoreBoard
+   */
+  #getHighestScore(scoreBoard) {
+    const [[_, winnerScore], ...rest] = scoreBoard;
+    this.#highestScore = winnerScore;
+  }
+
+  /**
+   * 가장 높은 전진 포인트를 가진 우승자(들)을 도출해낸다.
+   * @param {[string, number][]} scoreBoard
+   */
+  #setWinners(scoreBoard) {
+    this.winners = scoreBoard
+      .filter(([, score]) => this.#highestScore === score)
+      .map(([name, _]) => name)
+      .join(', ');
   }
 }
 

--- a/src/models/InputValidator.js
+++ b/src/models/InputValidator.js
@@ -10,14 +10,12 @@ class InputValidator {
   static carNames(carNames) {
     const { exceedName, emptyName, specialChar, duplicatedName } =
       ERROR_MESSAGES;
-    const { rSpecialChar } = REGEXS;
-    const { maxNaming } = OPTIONS;
 
     carNames.forEach((name, index) => {
       if (index > 2) throw new Error(exceedName);
-      if (name.length > maxNaming) throw new Error(exceedName);
+      if (name.length > OPTIONS.maxNaming) throw new Error(exceedName);
       if (!name.length) throw new Error(emptyName);
-      if (rSpecialChar.test(name)) throw new Error(specialChar);
+      if (REGEXS.rSpecialChar.test(name)) throw new Error(specialChar);
       if (index !== carNames.indexOf(name)) throw new Error(duplicatedName);
     });
   }
@@ -28,9 +26,8 @@ class InputValidator {
    */
   static laps(laps) {
     const { positive, integer } = ERROR_MESSAGES;
-    const { rWhiteSpace } = REGEXS;
 
-    if (rWhiteSpace.test(laps)) throw new Error('에러');
+    if (REGEXS.rWhiteSpace.test(laps)) throw new Error('에러');
     if (parseInt(laps, 10) < OPTIONS.minLaps) throw new Error(positive);
     if (Number.isNaN(parseInt(laps, 10))) throw new Error(integer);
   }

--- a/src/models/Race.js
+++ b/src/models/Race.js
@@ -1,14 +1,15 @@
 import randomNumberGenerator from '../utils/randomNumberGenerator.js';
 import OutputView from '../views/OutputView.js';
-import { GUIDE_MESSAGES } from '../constants/messages.js';
+import SYMBOLS from '../constants/symbols.js';
 import OPTIONS from '../constants/options.js';
+import Score from './Score.js';
 
 class Race {
   #outputView;
 
-  #booster;
+  #fuel;
 
-  #gas;
+  #score = new Score();
 
   constructor() {
     this.#outputView = OutputView;
@@ -16,61 +17,48 @@ class Race {
 
   /**
    * 주어진 조건에 따라 레이싱을 진행한다.
-   * TODO: scoreBoard의 type 변경
-   * @param {{[x: string]: number}} scoreBoard
+   * @param {[string, number][]} scoreBoard
    * @param {number} laps
    * @returns {[string, number][]}
    */
   racing(scoreBoard, laps) {
-    const { whiteSpace } = GUIDE_MESSAGES;
-    const scoreBoards = Object.entries(scoreBoard);
-
     while (laps) {
-      this.#drive(scoreBoards);
-      this.#outputView.print(whiteSpace);
+      this.#drive(scoreBoard);
+      this.#outputView.print(SYMBOLS.whiteSpace);
       laps--;
     }
 
-    return scoreBoards.sort((a, b) => b[1] - a[1]);
-  }
-
-  #drive(scoreBoards) {
-    scoreBoards.forEach(scoreBoard => {
-      this.#gasStation();
-      this.#getBooster();
-
-      if (this.#booster) scoreBoard += OPTIONS.point;
-    });
-    this.#showScoreBoard(scoreBoards);
+    return this.#score.sortBoard(scoreBoard);
   }
 
   /**
-   * 무작위 가스 값을 설정한다.
+   * 스코어보드 내 참가자들을 순회하며, 라운드를 진행한다.
+   * @param {[string, number][]} scoreBoard
+   * @returns
+   */
+  #drive(scoreBoard) {
+    scoreBoard.forEach(score => {
+      this.#gasStation();
+      this.#getBooster(score);
+    });
+
+    return this.#score.showBoard(scoreBoard);
+  }
+
+  /**
+   * 무작위 연료 값을 설정한다.
    * @private
    */
   #gasStation() {
-    this.#gas = randomNumberGenerator();
+    this.#fuel = randomNumberGenerator();
   }
 
   /**
-   * 가스가 일정 값 이상일 때 부스터 활성 여부를 설정한다.
+   * 연료가 일정 값 (OPTIONS.refuel = 4) 이상이면 부스터(전진 점수)를 얻는다.
    * @private
    */
-  #getBooster() {
-    const { refuel } = OPTIONS;
-    this.#booster = this.#gas >= refuel;
-  }
-
-  /**
-   * 모든 레이싱 완료 후 스코어보드를 출력한다.
-   * @param {[string, number][]} scoreBoards
-   * @private
-   */
-  #showScoreBoard(scoreBoards) {
-    const { lapScore, dash } = GUIDE_MESSAGES;
-    scoreBoards.forEach(score => {
-      this.#outputView.print(lapScore(score[0], dash.repeat(score[1])));
-    });
+  #getBooster(score) {
+    if (this.#fuel >= OPTIONS.refuel) score[1] += OPTIONS.point;
   }
 }
 

--- a/src/models/Score.js
+++ b/src/models/Score.js
@@ -1,19 +1,39 @@
+import { GUIDE_MESSAGES } from '../constants/messages.js';
+import OPTIONS from '../constants/options.js';
+import SYMBOLS from '../constants/symbols.js';
+import OutputView from '../views/OutputView.js';
 class Score {
-  constructor() {
-    this.scoreBoard = scoreBoard;
+  #outputView = OutputView;
+
+  /**
+   * 자동차 이름을 요소로 가진 단일 배열을, 이름과 점수를 가진 2차원 배열로 변환.
+   * @param {string[]} carNames
+   * @returns {[string, number][]}
+   */
+  static getBoard(carNames) {
+    return carNames.map(carName => [carName, OPTIONS.defaultPoint]);
   }
 
   /**
-   *
-   * @param {string[]} carNames
-   * @returns {[key: string]: number}
+   * 모든 레이싱 완료 후 스코어보드를 출력한다.
+   * @param {[string, number][]} scoreBoards
+   * @private
    */
-  static board(carNames) {
-    const scoreBoard = {};
+  showBoard(scoreBoard) {
+    return scoreBoard.forEach(([name, score]) => {
+      this.#outputView.print(
+        GUIDE_MESSAGES.lapScore(name, SYMBOLS.dash.repeat(score)),
+      );
+    });
+  }
 
-    carNames.forEach(el => (scoreBoard[el] = 0));
-
-    return scoreBoard;
+  /**
+   * 레이스 완료 후 점수를 기준으로 스코어보드 내림차순 정렬
+   * @param {[string, number][]} scoreBoard
+   * @returns {[string, number][]}
+   */
+  sortBoard(scoreBoard) {
+    return scoreBoard.sort((first, second) => second[1] - first[1]);
   }
 }
 

--- a/src/views/InputView.js
+++ b/src/views/InputView.js
@@ -1,23 +1,27 @@
 import { Console } from '@woowacourse/mission-utils';
 import { GUIDE_MESSAGES } from '../constants/messages.js';
 import InputValidator from '../models/InputValidator.js';
+import SYMBOLS from '../constants/symbols.js';
 
 class InputView {
   static async getCarNames() {
-    const input = await Console.readLineAsync(GUIDE_MESSAGES.carNames);
-    const carNames = input.split(',').map(el => el.trim());
+    const { comma } = SYMBOLS;
+    const carNames = (await Console.readLineAsync(GUIDE_MESSAGES.carNames))
+      .split(comma)
+      .map(carName => carName.trim());
 
     InputValidator.carNames(carNames);
 
     return carNames;
   }
 
+  // TODO: 입력 값이 숫자인 지에 대한 유효성 검증 필요. 정규표현식 추가해야한다.
   static async getLaps() {
     const laps = await Console.readLineAsync(GUIDE_MESSAGES.laps);
 
-    InputValidator.laps(parseInt(laps, 10));
+    InputValidator.laps(laps);
 
-    return parseInt(laps, 10);
+    return laps;
   }
 }
 


### PR DESCRIPTION
첫 번째 리팩토링 단계애서는 미비된 상수화와 모델 내 책임 분리와 분리한 책임을 명확화하였다.

1. 미비된 상수화.
 기존 `messages.js`에 위치해있던 심볼 요소인 comma, dash 등을 게임 내에서 사용되는 심볼들을 `symbols.js`에서 관리하도록 리팩토링
 
2. `📁/models/Awards.js` 내 메소드 책임 분리
기존의 Awards 클래스는 자동차 경주 레이싱 종료 후 결과 값을 기반으로 우승자를 처리하는 로직이었는데, `getWinners` 메소드에 너무 많은 책임이 부하되어 있어 `getHighestScore`, `setWinners` 등의 메소드 분리를 통해 메소드의 단일 책임을 확고히 했다.

3.  `📁/models/Race.js` Race 클래스의 책임 분리
기존의 Race 클래스는 자동차 경주의 책임을 갖는 클래스이나, 점수를 관리하는 Score 클래스가 존재에도 불구하고 점수 관리까지 담당하고 있었다. 이에 자동차의 전진 점수를 관리하는 `getBoard`, `showBoard`등의 메소드를 Score 클래스가 관리하도록 리팩토링 하였다.

4. 구조분해를 통한 코드의 가독성 증진.
입력된 자동차의 이름과 점수를 이중배열로 관리하도록 수정했는데, 이중배열에 접근하는 방식이 직접 인덱스 번호를 기재하며 인덱싱을 했지만 `n 번째 인덱스`의 개념과 가독성을 증진시키기 위해 직접 구조분해를 통해 리팩토링 하였다.

```javascript
// 리팩토링 이전
showBoard(scoreBoard) {
    return scoreBoard.forEach(score) => {
      this.#outputView.print(
        GUIDE_MESSAGES.lapScore(score[0], SYMBOLS.dash.repeat(score[1])),
      );
    });
  }

// 리팩토링 이후
showBoard(scoreBoard) {
    return scoreBoard.forEach(([name, score]) => {
      this.#outputView.print(
        GUIDE_MESSAGES.lapScore(name, SYMBOLS.dash.repeat(score)),
      );
    });
  }
```